### PR TITLE
Custom lang column

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,10 @@ emailAdapter: {
 --
 ### Multi language
 
-To be able to use Multi language is necesary set true `multiTemplate` and `multiLang`.
+To be able to use Multi language is necesary set `multiTemplate` and `multiLang` true and pass the column name where the language is stored in the `multiLangColumn` option. Default of `multiLangColumn` is `lang`.
 
-**Also in necessary to add a column called _lang_ in your User object** 
 
-The _lang_ column and the object needs to have the same value.
+_multiLangColumn_ and the object needs to have the same value.
 
 index.js
 ```js
@@ -268,6 +267,7 @@ emailAdapter: {
     confirmTemplatePath: "views/templates/confirmTemplate.html",
     passwordTemplatePath: "views/templates/passwordTemplate.html",
     multiLang: true,
+    multiLangColumn: "language", // Default is "lang".
     multiLangPass: {
       es: {
         subject: "Recuperación de Contraseña",

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ const nodemailer = require("nodemailer")
  * @param {String}    [confirmTemplatePath]     Path of the template file.
  * @param {String}    [passwordTemplatePath]    Path of the template file.
  * 
- * @param {boolean}   [multiLang]               When is True the emails can be send in different languages depending on the "lang" colum of the user object.
+ * @param {boolean}   [multiLang]               When is True the emails can be send in different languages depending on "multiLangColumn" of the user object.
+ * @param {boolean}   [multiLangColumn]         The name of the column where the language of the user is stored. Default is "lang".
  * @param {Object}    [multiLangPass]           Object with all the translations for the password recovery email.
  * @param {Object}    [multiLangConfirm]        Object with all the translations for the confirmation email.
  *
@@ -165,7 +166,8 @@ var SmtpMailAdapter = mailOptions => {
      * 
      * @param {String}     mailOptions.confirmTemplatePath      Path of the template file.
 
-     * @param {Boolean}    [_multiLang]                         If it's true you can send the emails in different languages (depending on the lang colum in the _User object).
+     * @param {Boolean}    [_multiLang]                         If it's true you can send the emails in different languages (depending on the "multiLangColumn" in the _User object).
+     * @param {Boolean}    [_multiLangColumn]                   The name of the column where the language of the user is stored. Default is "lang".
      * @param {Object}     [mailOptions.multiLangConfirm]       Object with all the translations.
      * 
      * @return
@@ -248,6 +250,7 @@ var SmtpMailAdapter = mailOptions => {
      * @param {String}     mailOptions.passwordTemplatePath     Path of the template file.
 
      * @param {Boolean}    [_multiLang]                         If it's true you can send the emails in different languages (depending on the lang colum in the _User object).
+     * @param {Boolean}    [_multiLangColumn]                   The name of the column where the language of the user is stored. Default is "lang".
      * @param {Object}     [mailOptions.multiLangPass]          Object with all the translations.
      *
      * @return

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ var SmtpMailAdapter = mailOptions => {
      * @param {String}     mailOptions.confirmTemplatePath      Path of the template file.
 
      * @param {Boolean}    [_multiLang]                         If it's true you can send the emails in different languages (depending on the "multiLangColumn" in the _User object).
-     * @param {Boolean}    [_multiLangColumn]                   The name of the column where the language of the user is stored. Default is "lang".
+     * @param {String}     [_multiLangColumn]                   The name of the column where the language of the user is stored. Default is "lang".
      * @param {Object}     [mailOptions.multiLangConfirm]       Object with all the translations.
      * 
      * @return
@@ -250,7 +250,7 @@ var SmtpMailAdapter = mailOptions => {
      * @param {String}     mailOptions.passwordTemplatePath     Path of the template file.
 
      * @param {Boolean}    [_multiLang]                         If it's true you can send the emails in different languages (depending on the lang colum in the _User object).
-     * @param {Boolean}    [_multiLangColumn]                   The name of the column where the language of the user is stored. Default is "lang".
+     * @param {String}     [_multiLangColumn]                   The name of the column where the language of the user is stored. Default is "lang".
      * @param {Object}     [mailOptions.multiLangPass]          Object with all the translations.
      *
      * @return

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ var SmtpMailAdapter = mailOptions => {
     var _templatePath = mailOptions.templatePath || "";
     var _multiTemplate = mailOptions.multiTemplate || false;
     var _multiLang = mailOptions.multiLang || false;
+    var _multiLangColumn = mailOptions.multiLangColumn || "lang";
  
     var transport = nodemailer.createTransport({
         host: mailOptions.host,
@@ -187,7 +188,7 @@ var SmtpMailAdapter = mailOptions => {
         const defOptions = mailOptions.confirmOptions;
         const options = mailOptions.passwordOptions.others || {};
         const langOptions = mailOptions.multiLangConfirm
-            ? mailOptions.multiLangConfirm[user.lang] : {};
+            ? mailOptions.multiLangConfirm[user[_multiLangColumn]] : {};
 
         let subject = (_multiLang && typeof langOptions !== 'undefined')
                         ? langOptions.subject
@@ -269,7 +270,7 @@ var SmtpMailAdapter = mailOptions => {
         const defOptions = mailOptions.passwordOptions;
         const options = mailOptions.passwordOptions.others || {};
         const langOptions = mailOptions.multiLangPass
-            ? mailOptions.multiLangPass[user.lang] : {};
+            ? mailOptions.multiLangPass[user[_multiLangColumn]] : {};
 
         let subject = (_multiLang && typeof langOptions !== 'undefined')
                         ? langOptions.subject


### PR DESCRIPTION
Our user's language code is not stored in the column "lang" but in "language". Having this as an option would be great. :) 

It's completely backwards compatbile, no one has to change their code.