### PR TITLE
Solved multi language issue with extra parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ var SmtpMailAdapter = mailOptions => {
         const link = data.link;
         const appName = data.appName;
         const defOptions = mailOptions.confirmOptions;
-        const options = mailOptions.passwordOptions.others || {};
+        const options = (_multiLang && mailOptions.multiLangConfirm) ? mailOptions.multiLangConfirm[user[_multiLangColumn]].others || {} : mailOptions.confirmOptions.others || {};
         const langOptions = mailOptions.multiLangConfirm
             ? mailOptions.multiLangConfirm[user[_multiLangColumn]] : {};
 
@@ -271,7 +271,7 @@ var SmtpMailAdapter = mailOptions => {
         const link = data.link;
         const appName = data.appName;
         const defOptions = mailOptions.passwordOptions;
-        const options = mailOptions.passwordOptions.others || {};
+        const options = (_multiLang && mailOptions.multiLangPass) ? mailOptions.multiLangPass[user[_multiLangColumn]].others || {} : mailOptions.passwordOptions.others || {};
         const langOptions = mailOptions.multiLangPass
             ? mailOptions.multiLangPass[user[_multiLangColumn]] : {};
 


### PR DESCRIPTION
If you use multi language extra parameters don't work (only default ones are loaded).
I've solved that issue setting options as:

`const options = (_multiLang && mailOptions.multiLangConfirm) ? mailOptions.multiLangConfirm[user[_multiLangColumn]].others || {} : mailOptions.confirmOptions.others || {};`

`const options = (_multiLang && mailOptions.multiLangPass) ? mailOptions.multiLangPass[user[_multiLangColumn]].others || {} : mailOptions.passwordOptions.others || {};`