### PR TITLE
Solved issue with SSL if Node >= 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ var SmtpMailAdapter = mailOptions => {
         auth: {
             user: mailOptions.user,
             pass: mailOptions.password
-        }
+        },
+        tls: { minVersion: "TLSv1" }
     });
 
     /**


### PR DESCRIPTION
When using SSL (`secure: true`) with **Node >= 12** email sending doesn't work (`SSL routines:ssl_choose_client_version:unsupported protocol`).
Adding tls settings with TLS min version the issue can be solved.